### PR TITLE
Use Electron instead of nwjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+run.sh

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Frameworks and tools used
 
-* React
-* nwjs
+* [React](https://reactjs.org/)
+* [Electron](https://electronjs.org/)
 
 ## To run
 
 - `npm install`
 - `npm install -g webpack`
 - `webpack --watch` (in one terminal)
-- `~/bin/nwjs-sdk-v0.26.2-osx-x64/nwjs.app/Contents/MacOS/nwjs .` (in another terminal, replace path as needed)
+- `NOTIME_API_ROOT=https://some-url npm start` (in another terminal, replace path as needed)

--- a/main.js
+++ b/main.js
@@ -1,0 +1,62 @@
+const electron = require('electron');
+
+// Module to control application life.
+const app = electron.app;
+
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow;
+
+const path = require('path');
+const url = require('url');
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow = null;
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({ width: 800, height: 600 });
+
+  // and load the index.html of the app.
+  mainWindow.loadURL(url.format({
+    pathname: path.join(__dirname, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  }));
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null;
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow);
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+});
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "notime",
   "version": "1.0.0",
   "description": "",
-  "main": "index.html",
+  "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "electron ."
   },
   "author": "",
   "license": "ISC",
@@ -21,8 +21,10 @@
   "devDependencies": {
     "awesome-typescript-loader": "^3.3.0",
     "css-loader": "^0.28.7",
+    "electron": "~1.7.8",
     "file-loader": "^1.1.5",
     "node-sass": "^4.6.0",
+    "request": "^2.83.0",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.19.0",

--- a/src/components/RouterView.tsx
+++ b/src/components/RouterView.tsx
@@ -6,12 +6,12 @@ import { TimeEntry } from './TimeEntry';
 
 export class RouterView extends React.Component<{}, {}> {
   public render() {
+    // TODO: breaks with reload, should likely use MemoryRouter instead.
     return (
       <div className='router-view'>
-        <Route exact path='/index.html' render={() => (
-            <Redirect to='/time_entry'/>
-          )
-        }/>
+        {/* Workaround since Electron loading the index.html from file doesn't allow us to just match the path
+            with /index.html */}
+        {window.location.pathname.includes('index.html') && <Redirect to='/time_entry' />}
         <Route path='/time_entry' component={TimeEntry}/>
         <Route path='/estimation' component={Estimation}/>
       </div>

--- a/src/components/TimeEntry.tsx
+++ b/src/components/TimeEntry.tsx
@@ -16,6 +16,10 @@ export class TimeEntry extends React.Component<{}, {}> {
   }
 
   public timesheetItems() {
+    debugger
+    const apiRoot = process.execPath; //process.env.NOTIME_API_ROOT;
+    console.log("Root:" + apiRoot);
+
     const items = [
       'Internal: Internal misc',
       'External: External misc',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { MemoryRouter as Router } from 'react-router-dom';
 
 import { IconBar } from './components/IconBar';
 import { RouterView } from './components/RouterView';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "sourceMap": true,
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es2016",
         "jsx": "react"
     },
     "include": [


### PR DESCRIPTION
I realized the compelling reason to use nwjs was flawed; we can use regular node modules in the browser context in Electron also...